### PR TITLE
Avoid browser trying to scroll on mobiles

### DIFF
--- a/web/js/sketchPad.js
+++ b/web/js/sketchPad.js
@@ -53,6 +53,7 @@ class SketchPad{
       this.canvas.ontouchmove=(evt)=>{
          const loc=evt.touches[0];
          this.canvas.onmousemove(loc);
+         evt.preventDefault()
       }
       document.ontouchend=()=>{
          document.onmouseup();


### PR DESCRIPTION
Hello,
This happens to me on Redmi Note 9 | Android 11 RP1A 200720.011 | Firefox 111.1.1. It also happens on same device with Chrome 112.0.5615
Everything else works fine.
Thanks for this great job!!

Miguel



